### PR TITLE
Mirror Discord avatar changes to Bluesky

### DIFF
--- a/AvatarCache.js
+++ b/AvatarCache.js
@@ -1,0 +1,48 @@
+/** @import { ImageURLOptions, User } from "discord.js" */
+
+/** I represent a cache for Discord user avatars. I am used when multiple networks need the same avatar with varying sizes and extensions. */
+class AvatarCache {
+	/**
+	 * @param {User} user
+	 */
+	constructor(user) {
+		/** @type {Map<string, Promise<Blob>} */
+        this.cachedBlobs = new Map();
+        this.user = user;
+	}
+
+	/**
+	 * Fetches the avatar data with the specified image URL options and populates the cache.
+	 * @param {ImageURLOptions} imageUrlOptions
+	 */
+	fetch(imageUrlOptions) {
+		const key = AvatarCache.getImageUrlOptionsKey(imageUrlOptions)
+		const cachedBlob = this.cachedBlobs.get(key)
+		if (cachedBlob) {
+            return cachedBlob;
+		} else {
+            const imageUrl = this.user.avatarURL(imageUrlOptions);
+            const fetchPromise = fetch(imageUrl).then((response) => {
+				if (!response.ok) {
+                    throw new Error(`HTTP error ${response.status}.`);
+				}
+                return response.blob();
+            }).catch((error) => {
+                this.cachedBlobs.delete(key);
+                throw error
+            })
+            this.cachedBlobs.set(key, fetchPromise);
+            return fetchPromise;
+		}
+	}
+
+	/**
+	 * @param {ImageURLOptions} imageUrlOptions
+	 * @returns {string}
+	 */
+	static getImageUrlOptionsKey(imageUrlOptions) {
+        return `${imageUrlOptions.forceStatic == true}${imageUrlOptions.size}${imageUrlOptions.extension}`;
+	}
+}
+
+module.exports = AvatarCache;

--- a/AvatarCache.js
+++ b/AvatarCache.js
@@ -2,30 +2,30 @@
 
 /** I represent a cache for Discord user avatars. I am used when multiple networks need the same avatar with varying sizes and extensions. */
 class AvatarCache {
-	/**
-	 * @param {User} user
-	 */
-	constructor(user) {
-		/** @type {Map<string, Promise<Blob>} */
+    /**
+     * @param {User} user
+     */
+    constructor(user) {
+        /** @type {Map<string, Promise<Blob>} */
         this.cachedBlobs = new Map();
         this.user = user;
-	}
+    }
 
-	/**
-	 * Fetches the avatar data with the specified image URL options and populates the cache.
-	 * @param {ImageURLOptions} imageUrlOptions
-	 */
-	fetch(imageUrlOptions) {
-		const key = AvatarCache.getImageUrlOptionsKey(imageUrlOptions)
-		const cachedBlob = this.cachedBlobs.get(key)
-		if (cachedBlob) {
+    /**
+     * Fetches the avatar data with the specified image URL options and populates the cache.
+     * @param {ImageURLOptions} imageUrlOptions
+     */
+    fetch(imageUrlOptions) {
+        const key = AvatarCache.getImageUrlOptionsKey(imageUrlOptions)
+        const cachedBlob = this.cachedBlobs.get(key)
+        if (cachedBlob) {
             return cachedBlob;
-		} else {
+        } else {
             const imageUrl = this.user.avatarURL(imageUrlOptions);
             const fetchPromise = fetch(imageUrl).then((response) => {
-				if (!response.ok) {
+                if (!response.ok) {
                     throw new Error(`HTTP error ${response.status}.`);
-				}
+                }
                 return response.blob();
             }).catch((error) => {
                 this.cachedBlobs.delete(key);
@@ -33,16 +33,16 @@ class AvatarCache {
             })
             this.cachedBlobs.set(key, fetchPromise);
             return fetchPromise;
-		}
-	}
+        }
+    }
 
-	/**
-	 * @param {ImageURLOptions} imageUrlOptions
-	 * @returns {string}
-	 */
-	static getImageUrlOptionsKey(imageUrlOptions) {
+    /**
+     * @param {ImageURLOptions} imageUrlOptions
+     * @returns {string}
+     */
+    static getImageUrlOptionsKey(imageUrlOptions) {
         return `${imageUrlOptions.forceStatic == true}${imageUrlOptions.size}${imageUrlOptions.extension}`;
-	}
+    }
 }
 
 module.exports = AvatarCache;

--- a/BLANK_config.json
+++ b/BLANK_config.json
@@ -7,5 +7,6 @@
     "discordBotToken": "",
     "discordGuildID": "",
     "discordChannelId": "",
-    "discordSuppressNotifications": true
+    "discordSuppressNotifications": true,
+    "discordMirrorAvatarUpdates": false
 }

--- a/Bluesky.js
+++ b/Bluesky.js
@@ -115,4 +115,19 @@ module.exports = class Bluesky extends Network {
     isEnabled() {
         return true;
     }
+
+    /**
+     * Sets the profile picture with the specified URL.
+     * @param {string} url The URL of the avatar,
+     */
+    async setAvatar(url) {
+        const avatarData = await super.setAvatar(url);
+        const blobUploadResponse = await bskyClient.uploadBlob(avatarData, {
+            encoding: "image/png",
+        });
+        await bskyClient.upsertProfile((record => {
+            record.avatar = blobUploadResponse.data.blob
+            return record
+        }));
+    }
 }

--- a/Bluesky.js
+++ b/Bluesky.js
@@ -6,6 +6,7 @@ const { default: AtpAgent } = require("@atproto/api"); // Bluesky AtProtocol bot
 const { config } = require(".");
 const Network = require("./Network");
 const bskyClient = new AtpAgent({ service: bskyURL });
+/** @import AvatarCache from './AvatarCache'; */
 
 /**
  * @type {Map<String, Promise<{uri: string;cid: string;}>>}
@@ -118,11 +119,15 @@ module.exports = class Bluesky extends Network {
 
     /**
      * Sets the profile picture with the specified URL.
-     * @param {string} url The URL of the avatar,
+     * @param {AvatarCache} avatarCache The avatar cache instance,
      */
-    async setAvatar(url) {
-        const avatarData = await super.setAvatar(url);
-        const blobUploadResponse = await bskyClient.uploadBlob(avatarData, {
+    async setAvatar(avatarCache) {
+        const avatarBlob = await avatarCache.fetch({
+            extension: "png",
+            forceStatic: true,
+            size: 512,
+        });
+        const blobUploadResponse = await bskyClient.uploadBlob(avatarBlob, {
             encoding: "image/png",
         });
         await bskyClient.upsertProfile((record => {

--- a/Bluesky.js
+++ b/Bluesky.js
@@ -118,8 +118,8 @@ module.exports = class Bluesky extends Network {
     }
 
     /**
-     * Sets the profile picture with the specified URL.
-     * @param {AvatarCache} avatarCache The avatar cache instance,
+     * Sets the profile picture from an AvatarCache instance.
+     * @param {AvatarCache} avatarCache The AvatarCache instance
      */
     async setAvatar(avatarCache) {
         const avatarBlob = await avatarCache.fetch({

--- a/Network.js
+++ b/Network.js
@@ -36,15 +36,10 @@ class Network {
 
     /**
      * Sets the profile picture with the specified URL.
-     * @param {string} url The URL of the avatar,
+     * @param {string} url The URL of the avatar.
      */
     async setAvatar(url) {
-        return fetch(url).then((response) => {
-            if (!response.ok) {
-                throw new Error(`HTTP error ${response.status}.`);
-            }
-            return response.blob();
-        })
+
     }
 }
 

--- a/Network.js
+++ b/Network.js
@@ -1,3 +1,5 @@
+/** @import AvatarCache from './AvatarCache'; */
+
 class Network {
     /**
      * Logs onto the network.
@@ -35,10 +37,10 @@ class Network {
     }
 
     /**
-     * Sets the profile picture with the specified URL.
-     * @param {string} url The URL of the avatar.
+     * Sets the profile picture from an AvatarCache instance.
+     * @param {AvatarCache} avatarCache The AvatarCache instance.
      */
-    async setAvatar(url) {
+    async setAvatar(avatarCache) {
 
     }
 }

--- a/Network.js
+++ b/Network.js
@@ -33,6 +33,19 @@ class Network {
     isEnabled() {
         return true;
     }
+
+    /**
+     * Sets the profile picture with the specified URL.
+     * @param {string} url The URL of the avatar,
+     */
+    async setAvatar(url) {
+        return fetch(url).then((response) => {
+            if (!response.ok) {
+                throw new Error(`HTTP error ${response.status}.`);
+            }
+            return response.blob();
+        })
+    }
 }
 
 module.exports = Network

--- a/index.js
+++ b/index.js
@@ -130,3 +130,29 @@ async function getReferencedMessage(root) {
 
     return replyChannel.messages.fetch(root.reference.messageId);
 }
+
+if (config.discordMirrorAvatarUpdates == true) {
+    /** @type {Discord.ImageURLOptions} */
+    const avatarImageUrlOptions = {
+        extension: "png",
+        forceStatic: true,
+    };
+
+    discordClient.on('userUpdate', (oldUser, newUser) => {
+        if (oldUser.userId == config.discordUserID) {
+            return;
+        }
+        const oldAvatarUrl = oldUser.avatarURL(avatarImageUrlOptions);
+        const newAvatarUrl = newUser.avatarURL(avatarImageUrlOptions);
+        if (oldAvatarUrl !== newAvatarUrl) {
+            // Avatar changed. Update to applicable networks.
+            networks.forEach(network => {
+                if (network.isEnabled()) {
+                    network.setAvatar(newAvatarUrl).catch((error) => {
+                        console.error(`Failed to update avatar on ${network.constructor.name}`, error)
+                    })
+                }
+            });
+        }
+    });
+}

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ if (config.discordMirrorAvatarUpdates == true) {
     };
 
     discordClient.on('userUpdate', (oldUser, newUser) => {
-        if (oldUser.userId == config.discordUserID) {
+        if (oldUser.id !== config.discordUserID) {
             return;
         }
         const oldAvatarUrl = oldUser.avatarURL(avatarImageUrlOptions);


### PR DESCRIPTION
## Motivation

On Discord, I change my avatar on a weekly basis. My statuses may be dependent on my current avatar as it is on Discord. So, it just seems like it would be neat if my Discord avatar mirrored to Bluesky, giving some of zhat context, even if it's often temporal.

## Implementation

I have only implemented setting profile pictures on Bluesky, but it should be straightforward to implement on different networks as `AvatarCache` can fetch and cache whatever Discord's CDN provides (jpeg, png, webp). Avatar mirroring can be configured in `config.json` as `discordMirrorAvatarUpdates`.


https://github.com/user-attachments/assets/9962b204-f019-4da3-817c-f78d8769bb9b

