### PR TITLE
Support self-hosted personal data servers

### DIFF
--- a/Bluesky.js
+++ b/Bluesky.js
@@ -1,12 +1,12 @@
-const bskyURL = 'https://bsky.social';
 const saveDataPath = "./bsky-posts.json";
 
 const fs = require('fs');
 const { default: AtpAgent } = require("@atproto/api"); // Bluesky AtProtocol bot stuff.
 const { config } = require(".");
 const Network = require("./Network");
-const bskyClient = new AtpAgent({ service: bskyURL });
+const { DidResolver, HandleResolver } = require("@atproto/identity");
 /** @import AvatarCache from './AvatarCache'; */
+/** @import { DidDocument } from '@atproto/identity'; */
 
 /**
  * @type {Map<String, Promise<{uri: string;cid: string;}>>}
@@ -40,31 +40,50 @@ process.on("beforeExit", () => {
     savePosts();
 });
 
-/**
- * @param {{uri: string;cid: string;}} post 
- * @returns {Promise<import('@atproto/api/dist/client/types/app/bsky/feed/defs').PostView>}
- */
-async function fetchPost(post) {
-    return (await bskyClient.getPosts({uris: [post.uri]})).data.posts[0];
-}
+class Resolver {
+    /**
+      * @param {string} handle - The account's handle.
+      * @returns {Promise<DidDocument | null>} The DID document.
+      * @throws {Error} If I am unable to find the specified {@link handle}'s DID document.
+      */
+    static async resolveDidDocumentFromHandle(handle) {
+        const did = await Resolver.#handleResolver.resolve(handle);
+        if (!did) throw new Error("Unable to resolve handle.");
+        const document = await Resolver.#didResolver.resolve(did);
+        return document
+    }
 
-/**
- * @param {{uri: string;cid: string;}} post 
- * @returns {Promise<import('@atproto/api/dist/client/types/app/bsky/feed/defs').PostView>}
- */
-async function fetchPost(post) {
-    return (await bskyClient.getPosts({uris: [post.uri]})).data.posts[0];
+    /**
+      * @param {string} handle - The account's handle.
+      * @returns {Promise<string>} The account's service endpoint.
+      * @throws {Error} If I am unable to find the specified {@link handle}'s PDS.
+      */
+    static async resolveServiceFromHandle(handle) {
+        const document = await Resolver.resolveDidDocumentFromHandle(handle)
+        if (!(document && document.service)) throw new Error("DID document does not specify services.");
+        const service = document.service.find(service => service.id == "#atproto_pds");
+        if (!service) throw new Error("DID document does not specify a personal data server.");
+        if (typeof service.serviceEndpoint !== "string") throw new Error("Service endpoint not found in document.");
+        return service.serviceEndpoint;
+    }
+    static #didResolver = new DidResolver({});
+    static #handleResolver = new HandleResolver({});
 }
 
 module.exports = class Bluesky extends Network {
     name = "Bluesky"
+    // Doesn't quite satisify TypeScript; thinks it could be undefined. Unsure of an elegant solution. Though, it doesn't matter on runtime.
+    /** @type {AtpAgent} */
+    blueskyClient
 
     /**
      * Logs onto the network.
      * @returns {Promise} Resolves when complete.
      */
-    logon() {
-        return bskyClient.login({ identifier: config.bskyName, password: config.bskyPass });
+    async logon() {
+        const serviceEndpoint = await Resolver.resolveServiceFromHandle(config.bskyName);
+        this.bskyClient = new AtpAgent({ service: serviceEndpoint });
+        return await this.bskyClient.login({ identifier: config.bskyName, password: config.bskyPass });
     }
 
     /**
@@ -73,7 +92,7 @@ module.exports = class Bluesky extends Network {
      * @returns {Promise} Resolves when complete.
      */
     post(thisStatus) {
-        let thisPost = bskyClient.post({ text: thisStatus });
+        let thisPost = this.bskyClient.post({ text: thisStatus });
         posts.set(thisStatus, thisPost);
         savePosts(); // Save after every post.
         return thisPost;
@@ -88,7 +107,7 @@ module.exports = class Bluesky extends Network {
     async replyTo(oldText, newText) {
         const parentPost = posts.get(oldText);
         if (parentPost != null) {
-            const parentAsObject = await fetchPost(await parentPost);
+            const parentAsObject = await this.#fetchPost(await parentPost);
             /**
              * I went through the effort of documenting this because apparently it wasn't written down anywhere? See the BlueskyReply file.
              * @type {import('./BlueskyReply').BlueskyReply | undefined}
@@ -96,7 +115,7 @@ module.exports = class Bluesky extends Network {
             const reply = parentAsObject.record.reply; 
             const root = reply ? reply.root : await parentPost;
             
-            const replyPost = bskyClient.post({
+            const replyPost = this.bskyClient.post({
                 text: newText,
                 reply: {
                     parent: await parentPost,
@@ -109,6 +128,14 @@ module.exports = class Bluesky extends Network {
 
             return replyPost;
         }
+    }
+
+    /**
+     * @param {{uri: string;cid: string;}} post 
+     * @returns {Promise<import('@atproto/api/dist/client/types/app/bsky/feed/defs').PostView>}
+     */
+    async #fetchPost(post) {
+        return (await this.bskyClient.getPosts({uris: [post.uri]})).data.posts[0];
     }
     
     /**
@@ -129,10 +156,10 @@ module.exports = class Bluesky extends Network {
             forceStatic: true,
             size: 512,
         });
-        const blobUploadResponse = await bskyClient.uploadBlob(avatarBlob, {
+        const blobUploadResponse = await this.bskyClient.uploadBlob(avatarBlob, {
             encoding: "image/png",
         });
-        await bskyClient.upsertProfile((record => {
+        await this.bskyClient.upsertProfile((record => {
             record.avatar = blobUploadResponse.data.blob
             return record
         }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@atproto/api": "^0.14.7",
+        "@atproto/identity": "^0.4.12",
         "discord.js": "^14.18.0",
         "masto": "^7.2.0"
       }
@@ -31,15 +32,73 @@
       }
     },
     "node_modules/@atproto/common-web": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.0.tgz",
-      "integrity": "sha512-ZYL0P9myHybNgwh/hBY0HaBzqiLR1B5/ie5bJpLQAg0whRzNA28t8/nU2vh99tbsWcAF0LOD29M8++LyENJLNQ==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/@atproto/common-web/-/common-web-0.4.21.tgz",
+      "integrity": "sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==",
       "license": "MIT",
       "dependencies": {
-        "graphemer": "^1.4.0",
-        "multiformats": "^9.9.0",
-        "uint8arrays": "3.0.0",
+        "@atproto/lex-data": "^0.0.15",
+        "@atproto/lex-json": "^0.0.16",
+        "@atproto/syntax": "^0.5.4",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@atproto/common-web/node_modules/@atproto/syntax": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.5.4.tgz",
+      "integrity": "sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@atproto/crypto": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@atproto/crypto/-/crypto-0.4.5.tgz",
+      "integrity": "sha512-n40aKkMoCatP0u9Yvhrdk6fXyOHFDDbkdm4h4HCyWW+KlKl8iXfD5iV+ECq+w5BM+QH25aIpt3/j6EUNerhLxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^1.7.0",
+        "@noble/hashes": "^1.6.1",
+        "uint8arrays": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
+    "node_modules/@atproto/identity": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@atproto/identity/-/identity-0.4.12.tgz",
+      "integrity": "sha512-P+Jn0HvKhIh1tps5n3xGrCxt+XiFWzp4kdgloyFhFmVLwjDU547DQkWx4r5Vhuiah7fRZGVSlk39R4U6SPrACg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/common-web": "^0.4.17",
+        "@atproto/crypto": "^0.4.5"
+      },
+      "engines": {
+        "node": ">=18.7.0"
+      }
+    },
+    "node_modules/@atproto/lex-data": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-data/-/lex-data-0.0.15.tgz",
+      "integrity": "sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.9.0",
+        "tslib": "^2.8.1",
+        "uint8arrays": "3.0.0",
+        "unicode-segmenter": "^0.14.0"
+      }
+    },
+    "node_modules/@atproto/lex-json": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@atproto/lex-json/-/lex-json-0.0.16.tgz",
+      "integrity": "sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@atproto/lex-data": "^0.0.15",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@atproto/lexicon": {
@@ -196,6 +255,33 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sapphire/async-queue": {
@@ -369,12 +455,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "license": "MIT"
     },
     "node_modules/header-case": {
@@ -561,6 +641,12 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
+    },
+    "node_modules/unicode-segmenter": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/unicode-segmenter/-/unicode-segmenter-0.14.5.tgz",
+      "integrity": "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==",
       "license": "MIT"
     },
     "node_modules/upper-case": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@atproto/api": "^0.14.7",
+    "@atproto/identity": "^0.4.12",
     "discord.js": "^14.18.0",
     "masto": "^7.2.0"
   }


### PR DESCRIPTION
When initializing the Bluesky client, the service field was hardcoded to `bsky.social`, a network of personal data servers hosted by Bluesky. This removes the hardcoded service and instead performs a lookup for a handle's personal data server.

I had to refactor some functions into the `Bluesky` network class to account for asynchronously initializing the `AtpAgent`.

- Resolves #5.
